### PR TITLE
Update environment variables

### DIFF
--- a/kendra_retriever_samples/README.md
+++ b/kendra_retriever_samples/README.md
@@ -1,5 +1,5 @@
 # AWS Langchain
-This repo provides a set of samples to work with [Langchain](https://github.com/hwchase17/langchain/tree/master) and Amazon Kendra. It currently has samples for working with a [Kendra retriever class](https://python.langchain.com/docs/modules/data_connection/retrievers/integrations/amazon_kendra_retriever) to execute a QA chain for SageMaker, Open AI and Anthropic providers. 
+This repo provides a set of samples to work with [Langchain](https://github.com/hwchase17/langchain/tree/master) and Amazon Kendra. It currently has samples for working with a [Kendra retriever class](https://python.langchain.com/docs/modules/data_connection/retrievers/integrations/amazon_kendra_retriever) to execute a QA chain for SageMaker, Open AI and Anthropic providers.
 
 ## Installing
 
@@ -27,26 +27,26 @@ pip install -r requirements.txt
 
 If you are using Conda
 ```bash
-conda env create -f environment.yml 
+conda env create -f environment.yml
 ```
 
 ## Running samples
 Ensure that the environment variables are set for the aws region, kendra index id and the provider/model used by the sample.
-For example, for running the `kendra_chat_flan_xl.py` sample, these environment variables must be set: AWS_REGION, KENDRA_INDEX_ID
+For example, for running the `kendra_chat_flan_xl.py` sample, these environment variables must be set: AWS_DEFAULT_REGION, KENDRA_INDEX_ID
 and FLAN_XL_ENDPOINT.
 
 You can use commands as below to set the environment variables.
 ```bash
-export AWS_REGION="<YOUR-AWS-REGION>"
+export AWS_DEFAULT_REGION="<YOUR-AWS-REGION>"
 export KENDRA_INDEX_ID="<YOUR-KENDRA-INDEX-ID>"
-export FLAN_XL_ENDPOINT="<YOUR-SAGEMAKER-ENDPOINT-FOR-FLAN-T-XL>"
-export FLAN_XXL_ENDPOINT="<YOUR-SAGEMAKER-ENDPOINT-FOR-FLAN-T-XXL>"
+export FLAN_XL_ENDPOINT="<YOUR-SAGEMAKER-ENDPOINT-NAME-FOR-FLAN-T-XL>"
+export FLAN_XXL_ENDPOINT="<YOUR-SAGEMAKER-ENDPOINT-NAME-FOR-FLAN-T-XXL>"
 export OPENAI_API_KEY="<YOUR-OPEN-AI-API-KEY>"
 export ANTHROPIC_API_KEY="<YOUR-ANTHROPIC-API-KEY>"
 ```
 
 ### Running samples from the streamlit app
-The samples directory is bundled with an `app.py` file that can be run as a web app using streamlit. 
+The samples directory is bundled with an `app.py` file that can be run as a web app using streamlit.
 
 ```bash
 streamlit run app.py anthropic
@@ -65,4 +65,3 @@ See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more inform
 
 ## License
 This library is licensed under the MIT-0 License. See the LICENSE file.
-


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* 

1. To avoid the error "botocore.exceptions.EndpointConnectionError: Unable to connect to endpoint URL", it seems correct to write `AWS_DEFAULT_REGION` instead of `AWS_REGION` as per [Amazon Boto3 documentation](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#using-environment-variables).

2. To avoid confusion between 'Endpoint arn' and 'Endpoint name', I gave the environment variables example a NAME.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
