### PR TITLE
Upgraded langchain to >=0.0.219

### DIFF
--- a/kendra_retriever_samples/environment.yml
+++ b/kendra_retriever_samples/environment.yml
@@ -5,7 +5,7 @@ dependencies:
   - python=3.10
   - pip
   - pip:
-    - langchain>=0.0.213
+    - langchain>=0.0.219
     - boto3>=1.26.159
     - openai
     - anthropic

--- a/kendra_retriever_samples/requirements.txt
+++ b/kendra_retriever_samples/requirements.txt
@@ -1,4 +1,4 @@
-langchain>=0.0.213
+langchain>=0.0.219
 boto3>=1.26.159
 openai
 anthropic


### PR DESCRIPTION
### Description of changes
Upgrades the Langchain version to >=0.0.219. There is a small bug fix for query API introduced in 0.0.218. Here is the related PR [#6849](https://github.com/hwchase17/langchain/pull/6849).  
