### PR TITLE
Fix: pass region to AmazonKendraRetriever

### DIFF
--- a/kendra_retriever_samples/kendra_chat_anthropic.py
+++ b/kendra_retriever_samples/kendra_chat_anthropic.py
@@ -25,7 +25,7 @@ def build_chain():
 
   llm = Anthropic(temperature=0, anthropic_api_key=ANTHROPIC_API_KEY, max_tokens_to_sample = 512)
       
-  retriever = AmazonKendraRetriever(index_id=kendra_index_id)
+  retriever = AmazonKendraRetriever(index_id=kendra_index_id, region_name=region)
 
   prompt_template = """
 

--- a/kendra_retriever_samples/kendra_chat_flan_xl.py
+++ b/kendra_retriever_samples/kendra_chat_flan_xl.py
@@ -46,7 +46,7 @@ def build_chain():
           content_handler=content_handler
       )
       
-  retriever = AmazonKendraRetriever(index_id=kendra_index_id)
+  retriever = AmazonKendraRetriever(index_id=kendra_index_id, region_name=region)
 
   prompt_template = """
   The following is a friendly conversation between a human and an AI. 

--- a/kendra_retriever_samples/kendra_chat_flan_xxl.py
+++ b/kendra_retriever_samples/kendra_chat_flan_xxl.py
@@ -46,7 +46,7 @@ def build_chain():
           content_handler=content_handler
       )
       
-  retriever = AmazonKendraRetriever(index_id=kendra_index_id)
+  retriever = AmazonKendraRetriever(index_id=kendra_index_id, region_name=region)
 
   prompt_template = """
   The following is a friendly conversation between a human and an AI. 

--- a/kendra_retriever_samples/kendra_chat_open_ai.py
+++ b/kendra_retriever_samples/kendra_chat_open_ai.py
@@ -13,7 +13,7 @@ def build_chain():
 
   llm = OpenAI(batch_size=5, temperature=0, max_tokens=300)
       
-  retriever = AmazonKendraRetriever(index_id=kendra_index_id)
+  retriever = AmazonKendraRetriever(index_id=kendra_index_id, region_name=region)
 
   prompt_template = """
   The following is a friendly conversation between a human and an AI. 

--- a/kendra_retriever_samples/kendra_retriever_anthropic.py
+++ b/kendra_retriever_samples/kendra_retriever_anthropic.py
@@ -12,7 +12,7 @@ def build_chain():
 
   llm = Anthropic(temperature=0, anthropic_api_key=ANTHROPIC_API_KEY)
         
-  retriever = AmazonKendraRetriever(index_id=kendra_index_id)
+  retriever = AmazonKendraRetriever(index_id=kendra_index_id, region_name=region)
 
   prompt_template = """
 

--- a/kendra_retriever_samples/kendra_retriever_flan_xl.py
+++ b/kendra_retriever_samples/kendra_retriever_flan_xl.py
@@ -34,7 +34,7 @@ def build_chain():
             content_handler=content_handler
         )
 
-    retriever = AmazonKendraRetriever(index_id=kendra_index_id)
+    retriever = AmazonKendraRetriever(index_id=kendra_index_id, region_name=region)
 
     prompt_template = """
     The following is a friendly conversation between a human and an AI. 

--- a/kendra_retriever_samples/kendra_retriever_flan_xxl.py
+++ b/kendra_retriever_samples/kendra_retriever_flan_xxl.py
@@ -33,8 +33,7 @@ def build_chain():
             model_kwargs={"temperature":1e-10, "max_length": 500},
             content_handler=content_handler
         )
-
-    retriever = AmazonKendraRetriever(index_id=kendra_index_id)
+    retriever = AmazonKendraRetriever(index_id=kendra_index_id, region_name=region)
 
     prompt_template = """
     The following is a friendly conversation between a human and an AI. 

--- a/kendra_retriever_samples/kendra_retriever_open_ai.py
+++ b/kendra_retriever_samples/kendra_retriever_open_ai.py
@@ -11,7 +11,7 @@ def build_chain():
 
   llm = OpenAI(batch_size=5, temperature=0, max_tokens=300)
 
-  retriever = AmazonKendraRetriever(index_id=kendra_index_id)
+  retriever = AmazonKendraRetriever(index_id=kendra_index_id, region_name=region)
 
   prompt_template = """
   The following is a friendly conversation between a human and an AI. 


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
The environment variable AWS_REGION was not passed to the AmazonKendraRetriever. It will fall back by reading either the `AWS_DEFAULT_REGION` env var or use the `~/.aws/config` file. This will cause the application to fail when the default region is different from the region specified in the `AWS_REGION` variable.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
