### PR TITLE
Add Amazon Bedrock Titan example

### DIFF
--- a/kendra_retriever_samples/app.py
+++ b/kendra_retriever_samples/app.py
@@ -8,6 +8,7 @@ import kendra_chat_flan_xxl as flanxxl
 import kendra_chat_open_ai as openai
 import kendra_chat_falcon_40b as falcon40b
 import kendra_chat_llama_2 as llama2
+import kendra_chat_bedrock_titan as titan
 
 USER_ICON = "images/user-icon.png"
 AI_ICON = "images/ai-icon.png"
@@ -18,7 +19,8 @@ PROVIDER_MAP = {
     'flanxl': 'Flan XL',
     'flanxxl': 'Flan XXL',
     'falcon40b': 'Falcon 40B',
-    'llama2' : 'Llama 2'
+    'llama2' : 'Llama 2',
+    'titan' : 'Amazon Bedrock Titan'
 }
 
 # Check if the user ID is already stored in the session state
@@ -51,10 +53,13 @@ if 'llm_chain' not in st.session_state:
         elif (sys.argv[1] == 'llama2'):
             st.session_state['llm_app'] = llama2
             st.session_state['llm_chain'] = llama2.build_chain()
+        elif (sys.argv[1] == 'titan'):
+            st.session_state['llm_app'] = titan
+            st.session_state['llm_chain'] = titan.build_chain()
         else:
             raise Exception("Unsupported LLM: ", sys.argv[1])
     else:
-        raise Exception("Usage: streamlit run app.py <anthropic|flanxl|flanxxl|openai>")
+        raise Exception("Usage: streamlit run app.py <anthropic|flanxl|flanxxl|openai|titan>")
 
 if 'chat_history' not in st.session_state:
     st.session_state['chat_history'] = []

--- a/kendra_retriever_samples/kendra_chat_bedrock_titan.py
+++ b/kendra_retriever_samples/kendra_chat_bedrock_titan.py
@@ -1,0 +1,93 @@
+from langchain.retrievers import AmazonKendraRetriever
+from langchain.chains import ConversationalRetrievalChain
+from langchain.prompts import PromptTemplate
+from langchain.llms.bedrock import Bedrock
+import sys
+import os
+import boto3
+
+MAX_HISTORY_LENGTH = 5
+
+def get_llm():
+  bedrock_client = boto3.client('bedrock')
+  model_args = {'temperature':0}
+  bedrock_llm = Bedrock(model_id="amazon.titan-tg1-large",client=bedrock_client,model_kwargs=model_args)
+  return bedrock_llm
+
+def build_chain():
+  region = os.environ["AWS_REGION"]
+  kendra_index_id = os.environ["KENDRA_INDEX_ID"]
+
+  llm = get_llm()
+
+  retriever = AmazonKendraRetriever(index_id=kendra_index_id, region_name=region)
+
+  prompt_template = """
+  The following is a friendly conversation between a human and an AI. 
+  The AI is talkative and provides lots of specific details from its context.
+  If the AI does not know the answer to a question, it truthfully says it 
+  does not know.
+  {context}
+  Instruction: Based on the above documents, provide a detailed answer for, {question} Answer "don't know" 
+  if not present in the document. 
+  Solution:"""
+  PROMPT = PromptTemplate(
+      template=prompt_template, input_variables=["context", "question"]
+  )
+
+  condense_qa_template = """
+  Given the following conversation and a follow up question, rephrase the follow up question 
+  to be a standalone question.
+
+  Chat History:
+  {chat_history}
+  Follow Up Input: {question}
+  Standalone question:"""
+  standalone_question_prompt = PromptTemplate.from_template(condense_qa_template)
+
+  qa = ConversationalRetrievalChain.from_llm(
+        llm=llm, 
+        retriever=retriever, 
+        condense_question_prompt=standalone_question_prompt, 
+        return_source_documents=True, 
+        combine_docs_chain_kwargs={"prompt":PROMPT})
+  return qa
+
+def run_chain(chain, prompt: str, history=[]):
+  return chain({"question": prompt, "chat_history": history})
+
+
+if __name__ == "__main__":
+  class bcolors:
+    HEADER = '\033[95m'
+    OKBLUE = '\033[94m'
+    OKCYAN = '\033[96m'
+    OKGREEN = '\033[92m'
+    WARNING = '\033[93m'
+    FAIL = '\033[91m'
+    ENDC = '\033[0m'
+    BOLD = '\033[1m'
+    UNDERLINE = '\033[4m'
+
+  qa = build_chain()
+  chat_history = []
+  print(bcolors.OKBLUE + "Hello! How can I help you?" + bcolors.ENDC)
+  print(bcolors.OKCYAN + "Ask a question, start a New search: or CTRL-D to exit." + bcolors.ENDC)
+  print(">", end=" ", flush=True)
+  for query in sys.stdin:
+    if (query.strip().lower().startswith("new search:")):
+      query = query.strip().lower().replace("new search:","")
+      chat_history = []
+    elif (len(chat_history) == MAX_HISTORY_LENGTH):
+      chat_history.pop(0)
+    result = run_chain(qa, query, chat_history)
+    chat_history.append((query, result["answer"]))
+    print(bcolors.OKGREEN + result['answer'] + bcolors.ENDC)
+    if 'source_documents' in result:
+      print(bcolors.OKGREEN + 'Sources:')
+      for d in result['source_documents']:
+        print(d.metadata['source'])
+    print(bcolors.ENDC)
+    print(bcolors.OKCYAN + "Ask a question, start a New search: or CTRL-D to exit." + bcolors.ENDC)
+    print(">", end=" ", flush=True)
+  print(bcolors.OKBLUE + "Bye" + bcolors.ENDC)

--- a/kendra_retriever_samples/kendra_retriever_bedrock_titan.py
+++ b/kendra_retriever_samples/kendra_retriever_bedrock_titan.py
@@ -1,0 +1,60 @@
+import os
+import boto3
+from langchain.retrievers import AmazonKendraRetriever
+from langchain.chains import RetrievalQA
+from langchain.llms.bedrock import Bedrock
+from langchain.prompts import PromptTemplate
+
+def get_llm():
+  bedrock_client = boto3.client('bedrock')
+  model_args = {'temperature':0}
+  bedrock_llm = Bedrock(model_id="amazon.titan-tg1-large",client=bedrock_client,model_kwargs=model_args)
+  return bedrock_llm
+
+def build_chain():
+  region = os.environ["AWS_REGION"]
+  kendra_index_id = os.environ["KENDRA_INDEX_ID"]
+
+  llm = get_llm()
+
+  retriever = AmazonKendraRetriever(index_id=kendra_index_id,region_name=region)
+
+  prompt_template = """
+  The following is a friendly conversation between a human and an AI.
+  The AI is talkative and provides lots of specific details from its context.
+  If the AI does not know the answer to a question, it truthfully says it
+  does not know.
+  {context}
+  Instruction: Based on the above documents, provide a detailed answer for, {question} Answer "don't know"
+  if not present in the document.
+  Solution:"""
+  PROMPT = PromptTemplate(
+      template=prompt_template, input_variables=["context", "question"]
+  )
+  chain_type_kwargs = {"prompt": PROMPT}
+
+  return RetrievalQA.from_chain_type(
+      llm,
+      chain_type="stuff",
+      retriever=retriever,
+      chain_type_kwargs=chain_type_kwargs,
+      return_source_documents=True
+  )
+
+def run_chain(chain, prompt: str, history=[]):
+    result = chain(prompt)
+    # To make it compatible with chat samples
+    return {
+        "answer": result['result'],
+        "source_documents": result['source_documents']
+    }
+
+if __name__ == "__main__":
+    chain = build_chain()
+    result = run_chain(chain, "What's SageMaker?")
+    print(result['answer'])
+    if 'source_documents' in result:
+        print('Sources:')
+        for d in result['source_documents']:
+          print(d.metadata['source'])
+


### PR DESCRIPTION
*Description of changes:*
This provides an example of how to implement the langchain kendra retriever with Amazon Bedrock's Titan LLM. It is based on the OpenAI example and works in the same way, substituting the different services. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
