### PR TITLE
Update requirements.txt

### DIFF
--- a/kendra_retriever_samples/requirements.txt
+++ b/kendra_retriever_samples/requirements.txt
@@ -1,5 +1,5 @@
-langchain==0.0.279
-boto3>=1.28.27
+langchain>=0.0.306
+boto3>=1.28.57
 openai
 anthropic
 streamlit


### PR DESCRIPTION
*Description of changes:*

Updated version requirements for langchain and boto3 to versions that have Bedrock support. (only important if you are using the Bedrock/Claude retriever).  This fixes the error from langchain that says, "Error raised by bedrock service: 'Bedrock' object has no attribute 'invoke_model'"


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
