### PR TITLE
Update kendra_chat_bedrock_claudev2.py

### DIFF
--- a/kendra_retriever_samples/kendra_chat_bedrock_claudev2.py
+++ b/kendra_retriever_samples/kendra_chat_bedrock_claudev2.py
@@ -58,13 +58,13 @@ def build_chain():
       template=prompt_template, input_variables=["context", "question"]
   )
 
-  condense_qa_template = """Human: 
-  Given the following conversation and a follow up question, rephrase the follow up question 
+  condense_qa_template = """{chat_history}
+  Human:
+  Given the previous conversation and a follow up question below, rephrase the follow up question
   to be a standalone question.
-  Chat History:
-  {chat_history}
-  Follow Up Input: {question}
-  Standalone question: 
+
+  Follow Up Question: {question}
+  Standalone Question:
 
   Assistant:"""
   standalone_question_prompt = PromptTemplate.from_template(condense_qa_template)


### PR DESCRIPTION
*Issue #, if available:This also fixes issue #45

*Description of changes:*
I put the chat history at the beginning of the prompt instead of in the middle.  
The order of the history had to be changed because the Bedrock API expects to see alternating Human:/Assistant: lines for Claude.  Without this change, the first query would work, but subsequent queries would generate an error from the Bedrock API:  

ValueError: Error: Prompt must alternate between '

Human:' and '

Assistant:'.




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
