### PR TITLE
updated handling of profile name in claude v2 script

### DIFF
--- a/kendra_retriever_samples/kendra_chat_bedrock_claudev2.py
+++ b/kendra_retriever_samples/kendra_chat_bedrock_claudev2.py
@@ -23,17 +23,22 @@ MAX_HISTORY_LENGTH = 5
 def build_chain():
   region = os.environ["AWS_REGION"]
   kendra_index_id = os.environ["KENDRA_INDEX_ID"]
-  credentials_profile_name = os.environ['AWS_PROFILE']
 
-  print(credentials_profile_name)
-
-
-  llm = Bedrock(
+  if "AWS_PROFILE" in os.environ:
+    credentials_profile_name = os.environ['AWS_PROFILE']
+    print("Using " + credentials_profile_name + " profile.")
+    llm = Bedrock(
       credentials_profile_name=credentials_profile_name,
       region_name = region,
       model_kwargs={"max_tokens_to_sample":300,"temperature":1,"top_k":250,"top_p":0.999,"anthropic_version":"bedrock-2023-05-31"},
       model_id="anthropic.claude-v2"
-  )
+    )
+  else:
+    llm = Bedrock(
+      region_name = region,
+      model_kwargs={"max_tokens_to_sample":300,"temperature":1,"top_k":250,"top_p":0.999,"anthropic_version":"bedrock-2023-05-31"},
+      model_id="anthropic.claude-v2"
+    )
       
   retriever = AmazonKendraRetriever(index_id=kendra_index_id,top_k=5,region_name=region)
 


### PR DESCRIPTION
This PR updates how the scripts handles presense of an AWS profile name.
If an AWS profile is present in the environment variables, the scripts uses it to communicate with Bedrock and Kendra.
If an AWS profile does not exist in the environment variables, the script will use the default profile.

Note, if you are running on SageMaker Studio Classic, the default profile will be your instance's IAM Execution Role so make sure it has the right IAM permissions to invoke models on Bedrock and query and retrieve from Kendra.

This has been tested on SageMaker Studio Classic with and without an AWS Profile defined. Both worked as expected.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
